### PR TITLE
Refactor WASM compilation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,5 +17,7 @@ jobs:
         with:
           submodules: 'true'
       - uses: mlugg/setup-zig@v1
+        with:
+          version: 0.14.0-dev.3427+dea72d15d
       - run: sudo apt install -y glslc libx11-dev libxcursor-dev libxrandr-dev libxinerama-dev libxi-dev libvulkan-dev libgl-dev
       - run: zig build

--- a/build.zig
+++ b/build.zig
@@ -55,23 +55,21 @@ pub fn build(b: *std.Build) void {
     }, .flags = &[_][]const u8{ "-D_GLFW_X11", "-Wall", "-Wextra" } });
     glfw.linkLibC();
 
-    const opengl = b.option(bool, "opengl", "Use OpenGL instead of Vulkan.") orelse false;
-
     const exe = b.addExecutable(.{
         .root_source_file = b.path("src/main.zig"),
         .target = target,
         .optimize = optimize,
         .name = "explora",
     });
+    exe.addIncludePath(b.path("ext/glfw/include"));
 
     //  If "opengl" was passed as an option, this statement will define USE_OPENGL,
     //  which will be checked inside renderer.zig, it will use the opengl backend if that was defined,
     //  else it won't thus the backend will be vulkan
+    const opengl = b.option(bool, "opengl", "Use OpenGL instead of Vulkan.") orelse false;
     const options = b.addOptions();
     options.addOption(bool, "opengl", opengl);
     exe.root_module.addOptions("config", options);
-    exe.linkSystemLibrary("vulkan");
-    exe.addIncludePath(b.path("ext/glfw/include"));
     if (opengl) {
       exe.addIncludePath(b.path("ext/gl/include"));
       exe.addCSourceFile(.{
@@ -79,6 +77,7 @@ pub fn build(b: *std.Build) void {
           .flags = &[_][]const u8{"-Iinclude"},
       });
     } else {
+      exe.linkSystemLibrary("vulkan");
       compileAllShaders(b, exe);
     }
     exe.linkLibrary(glfw);

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,15 +1,14 @@
 const std = @import("std");
 const c = @import("c.zig");
 const window = @import("render/window.zig");
-//const vk = @import("render/vulkan.zig");
-const gl = @import("render/opengl.zig");
-//const Renderer = @import("render/renderer.zig");
+
+const config = @import("config");
+const Renderer = if (config.opengl) @import("render/renderer_opengl.zig") else @import("render/renderer_vulkan.zig");
+
 const math = @import("math.zig");
 const Parser = @import("vm/parse.zig");
 const vm = @import("vm/vm.zig");
 const wasm = @import("vm/wasm.zig");
-
-// @h3llll : I've temporarly commented vulkan code because im too lazy to figure out how to make the build system chose the library at compiletime and not check for it at runtime because that's just ugly and ugh i hate if statements so yeah
 
 pub fn main() !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
@@ -28,15 +27,14 @@ pub fn main() !void {
         const w = try window.Window.create(800, 600, "explora");
         defer w.destroy();
 
-        //var r = try Renderer.create(allocator, w);
-        //defer r.destroy();
+        // TODO: Renderer.destroy should not return an error?
+        var r = try Renderer.create(allocator, w);
+        defer r.destroy() catch {};
 
         while (!w.shouldClose()) {
             c.glfwPollEvents();
-            //try r.tick();
+            try r.tick();
         }
-
-        //try r.device.waitIdle();
     }
 
     if (gpa.detectLeaks()) {

--- a/src/main.zig
+++ b/src/main.zig
@@ -17,7 +17,9 @@ pub fn main() !void {
         var global_runtime = wasm.GlobalRuntime.init(allocator);
         defer global_runtime.deinit();
         try global_runtime.addFunction("debug", wasm.debug);
-        const module = try Parser.parseWasm(allocator);
+
+        const file = try std.fs.cwd().openFile("assets/core.wasm", .{});
+        const module = try Parser.parseWasm(allocator, file.reader());
         var runtime = try vm.Runtime.init(allocator, module, &global_runtime);
         defer runtime.deinit(allocator);
 

--- a/src/render/opengl.zig
+++ b/src/render/opengl.zig
@@ -1,5 +1,5 @@
 const c = @cImport({
-    @cDefine("GLAD_GL_IMPLEMENTATION", "1"); // Tells glad to implement the functions(believe me idk why)
+    @cDefine("GLAD_GL_IMPLEMENTATION", "1"); // Tells glad to implement the functions, this is standard in single header libraries (check out STB for a good example)
     @cInclude("glad.h");
 });
 

--- a/src/render/renderer_opengl.zig
+++ b/src/render/renderer_opengl.zig
@@ -1,0 +1,25 @@
+const c = @import("../c.zig");
+const std = @import("std");
+const window = @import("window.zig");
+const mesh = @import("mesh.zig");
+const Allocator = std.mem.Allocator;
+
+const Renderer = @This();
+
+
+pub fn create(allocator: Allocator, w: window.Window) !Renderer {
+    _ = w;
+    _ = allocator;
+
+    return Renderer{
+    };
+}
+
+pub fn destroy(self: Renderer) !void {
+    _ = self;
+}
+
+// TODO: tick is maybe a bad name? something like present() or submit() is better?
+pub fn tick(self: *Renderer) !void {
+    _ = self;
+}

--- a/src/render/renderer_vulkan.zig
+++ b/src/render/renderer_vulkan.zig
@@ -61,7 +61,8 @@ pub fn create(allocator: Allocator, w: window.Window) !Renderer {
     };
 }
 
-pub fn destroy(self: Renderer) void {
+pub fn destroy(self: Renderer) !void {
+    try self.device.waitIdle();
     self.index_buffer.destroy(self.device.handle);
     self.vertex_buffer.destroy(self.device.handle);
     self.graphics_pipeline.destroy(self.device);

--- a/src/vm/parse.zig
+++ b/src/vm/parse.zig
@@ -2,27 +2,50 @@ const std = @import("std");
 const wasm = @import("wasm.zig");
 const Allocator = std.mem.Allocator;
 
+pub const Error = error {
+    malformed_wasm,
+    invalid_utf8,
+};
+
 pub const Module = struct {
     types: []FunctionType,
     imports: std.ArrayList(Import),
-    exports: std.StringHashMap(u8),
-    functions: []u8,
+    exports: std.StringHashMap(u32),
+    functions: []u32,
     memory: Memory,
-    contents: []u8,
     code: []FunctionBody,
     funcs: std.ArrayList(Function),
 
     pub fn deinit(self: *Module, allocator: Allocator) void {
-        for (self.code) |f| {
-            allocator.free(f.locals);
+        for (self.types) |t| {
+            t.deinit(allocator);
         }
+        allocator.free(self.types);
+
+        for (self.imports.items) |i| {
+            i.deinit(allocator);
+        }
+        self.imports.deinit();
+
+        var iter = self.exports.iterator();
+        while (iter.next()) |entry| {
+            allocator.free(entry.key_ptr.*);
+        }
+        self.exports.deinit();
+
+        allocator.free(self.functions);
+
+        for (self.code) |f| {
+            for (f.locals) |l| {
+                allocator.free(l.types);
+            }
+            allocator.free(f.code);
+        }
+        allocator.free(self.code);
 
         self.funcs.deinit();
-        self.imports.deinit();
-        self.exports.deinit();
-        allocator.free(self.code);
-        allocator.free(self.types);
-        allocator.free(self.contents);
+
+
     }
 };
 
@@ -36,6 +59,7 @@ pub const Function = union(FunctionScope) {
     internal: u8,
 };
 
+// TODO: refactor locals
 pub const Local = struct {
     types: []u8,
 };
@@ -46,183 +70,217 @@ pub const FunctionBody = struct {
 };
 
 pub const Memory = struct {
-    initial: u8,
-    max: u8,
+    initial: u32,
+    max: u32,
 };
 
 pub const FunctionType = struct {
     parameters: []u8,
     results: []u8,
+
+    pub fn deinit(self: FunctionType, allocator: Allocator) void {
+        allocator.free(self.parameters);
+        allocator.free(self.results);
+    }
 };
 
 pub const Import = struct {
     name: []u8,
     module: []u8,
-    signature: u8,
+    signature: u32,
+
+    pub fn deinit(self: Import, allocator: Allocator) void {
+        allocator.free(self.name);
+        allocator.free(self.module);
+    }
 };
 
 pub fn parseType(t: u8) wasm.Type {
     return @enumFromInt(t);
 }
 
+pub fn parseName(allocator: Allocator, stream: anytype) ![]u8 {
+    const size = try std.leb.readUleb128(u32, stream);
+    const str = try allocator.alloc(u8, size);
+    if (try stream.read(str) != size) {
+        // TODO: better error
+        return Error.malformed_wasm;
+    }
+
+    if (!std.unicode.utf8ValidateSlice(str)) return Error.invalid_utf8;
+
+    return str;
+}
+
 // TODO: parse Global Section
-pub fn parseWasm(allocator: Allocator) !Module {
-    const file = try std.fs.cwd().openFile("assets/core.wasm", .{});
-    const size = (try file.metadata()).size();
-
-    const contents = try file.reader().readAllAlloc(
-        allocator,
-        size,
-    );
-
+// TODO: Consider Arena allocator
+pub fn parseWasm(allocator: Allocator, stream: anytype) !Module {
     var types: []FunctionType = undefined;
     var imports = std.ArrayList(Import).init(allocator);
-    var exports = std.StringHashMap(u8).init(allocator);
+    var exports = std.StringHashMap(u32).init(allocator);
     var funcs = std.ArrayList(Function).init(allocator);
-    var functions: []u8 = undefined;
+    var functions: []u32 = undefined;
     var memory: Memory = undefined;
     var code: []FunctionBody = undefined;
 
-    var index = @as(usize, 8);
-    var byte = contents[index];
-    loop: while (index < (size - 1)) {
-        const sec_size = contents[index + 1];
-        switch (byte) {
-            0x0 => break :loop,
-            // Type section
-            0x1 => {
-                index += 2;
-                const type_count = contents[index];
+    // Parse magic
+    if (!(try stream.isBytes(&[_]u8{ 0x00, 0x61, 0x73, 0x6d }))) return Error.malformed_wasm;
+    // Parse version
+    if (!(try stream.isBytes(&[_]u8{ 0x01, 0x00, 0x00, 0x00 }))) return Error.malformed_wasm;
+
+    // NOTE: This ensures that (in this block) illegal behavior is safety-checked.
+    //     This slows down the code but since this function is only called at the start
+    //     I believe it is better to take the ``hit'' in performance (should only be @enumFromInt)
+    //     rather than  having undefined behavior when user provides an invalid wasm file.
+    @setRuntimeSafety(true);
+    loop: while (stream.readByte()) |byte| {
+        const section_size  = try std.leb.readUleb128(u32, stream);
+        switch (@as(std.wasm.Section, @enumFromInt(byte))) {
+            std.wasm.Section.custom => {
+                // TODO: unimplemented
+                break :loop;
+            },
+            std.wasm.Section.type => {
+                const type_count = try std.leb.readUleb128(u32, stream);
                 types = try allocator.alloc(FunctionType, type_count);
-                index += 1;
-                for (0..type_count) |t| {
-                    index += 1;
-                    const params = contents[index];
-                    index += 1;
-                    types[t].parameters = contents[index..(index + params)];
-                    index += params;
-
-                    const results = contents[index];
-                    index += 1;
-                    types[t].results = contents[index..(index + results)];
-                    index += results;
+                for (types) |*t| {
+                    if (!(try stream.isBytes(&.{ 0x60 }))) return Error.malformed_wasm;
+                    const params_count = try std.leb.readUleb128(u32, stream);
+                    t.parameters = try allocator.alloc(u8, params_count);
+                    if (try stream.read(t.parameters) != params_count) {
+                        // TODO: better errors
+                        return Error.malformed_wasm;
+                    }
+                    const results = try std.leb.readUleb128(u32, stream);
+                    t.results = try allocator.alloc(u8, results);
+                    if (try stream.read(t.results) != results) {
+                        // TODO: better errors
+                        return Error.malformed_wasm;
+                    }
                 }
             },
-            // Import section
-            0x2 => {
-                index += 2;
-                const import_count = contents[index];
-                index += 1;
+            std.wasm.Section.import => {
+                // Can there be more than one import section?
+                const import_count = try std.leb.readUleb128(u32, stream);
                 for (0..import_count) |i| {
-                    var string_length = contents[index];
-                    index += 1;
-                    var import: Import = undefined;
-                    import.module = contents[index..(index + string_length)];
-                    index += string_length;
-                    string_length = contents[index];
-                    index += 1;
-                    import.name = contents[index..(index + string_length)];
-                    index += string_length;
+                    const mod = try parseName(allocator, stream);
+                    const nm = try parseName(allocator, stream);
 
-                    // kind (skip for now)
-                    index += 1;
-                    import.signature = contents[index];
-                    index += 1;
-                    try imports.append(import);
-                    const f = Function{
-                        .external = @intCast(i),
+                    const b = try stream.readByte();
+                    switch (@as(std.wasm.ExternalKind, @enumFromInt(b))) {
+                        std.wasm.ExternalKind.function => try funcs.append(.{ .external = @intCast(i) }),
+                            // TODO: not implemented
+                        std.wasm.ExternalKind.table => {},
+                        std.wasm.ExternalKind.memory => {},
+                        std.wasm.ExternalKind.global => {},
+                    }
+                    const idx = try std.leb.readUleb128(u32, stream);
+                    try imports.append(.{
+                        .module = mod,
+                        .name = nm,
+                        .signature = idx,
+                    });
+                }
+            },
+            std.wasm.Section.function => {
+                const function_count = try std.leb.readUleb128(u32, stream);
+                functions = try allocator.alloc(u32, function_count);
+                for (functions) |*f| {
+                    f.* = try std.leb.readUleb128(u32, stream);
+                }
+            },
+            std.wasm.Section.table => {
+                // TODO: not implemented
+                try stream.skipBytes(section_size, .{});
+            },
+            std.wasm.Section.memory => {
+                const memory_count = try std.leb.readUleb128(u32, stream);
+                for (0..memory_count) |_| {
+                    const b = try stream.readByte();
+                    const n = try std.leb.readUleb128(u32, stream);
+                    var m: u32 = 0;
+                    switch (b) {
+                        0x00 => {},
+                        0x01 => m = try std.leb.readUleb128(u32, stream),
+                        else => return Error.malformed_wasm,
+                    }
+                    // TODO: support multiple memories
+                    memory = .{
+                        .initial = n,
+                        .max = m,
                     };
-                    try funcs.append(f);
                 }
             },
-            // Function section
-            0x3 => {
-                index += 2;
-                const function_count = contents[index];
-                index += 1;
-                functions = contents[index..(index + function_count)];
-                index += function_count;
+            std.wasm.Section.global => {
+                // TODO: unimplemented
+                try stream.skipBytes(section_size, .{});
             },
-            // Memory section
-            0x5 => {
-                index += 3;
-                const flags = contents[index];
-                index += 1;
-                const initial = contents[index];
-                var max = @as(u8, 0);
-                index += 1;
-                if (flags == 1) {
-                    max = contents[index];
-                    index += 1;
-                }
-
-                memory = .{
-                    .initial = initial,
-                    .max = max,
-                };
-            },
-            // Export section
-            0x7 => {
-                index += 2;
-                const export_count = contents[index];
-                index += 1;
+            // TODO: Can there be more than one export section? Otherwise we can optimize allocations
+            std.wasm.Section.@"export" => {
+                const export_count = try std.leb.readUleb128(u32, stream);
                 for (0..export_count) |_| {
-                    const string_length = contents[index];
-                    index += 1;
-                    const name = contents[index..(index + string_length)];
-                    index += string_length;
-                    const kind = contents[index];
-                    index += 1;
-                    const signature = contents[index];
-                    index += 1;
-                    if (kind == 0x0) {
-                        try exports.put(name, signature);
+                    const nm = try parseName(allocator, stream);
+                    const b = try stream.readByte();
+                    const idx = try std.leb.readUleb128(u32, stream);
+                    switch (@as(std.wasm.ExternalKind, @enumFromInt(b))) {
+                        std.wasm.ExternalKind.function => try exports.put(nm, idx),
+                        // TODO: unimplemented,
+                        std.wasm.ExternalKind.table  => allocator.free(nm),
+                        std.wasm.ExternalKind.memory => allocator.free(nm),
+                        std.wasm.ExternalKind.global => allocator.free(nm),
                     }
                 }
             },
-            // Code section
-            0x0a => {
-                index += 2;
-                const function_count = contents[index];
-                code = try allocator.alloc(FunctionBody, function_count);
-                index += 1;
-                for (0..function_count) |i| {
-                    const function_size = contents[index];
-                    index += 1;
-                    const local_count = contents[index];
-                    index += 1;
-                    var locals: []Local = undefined;
-                    locals = try allocator.alloc(Local, local_count);
-                    if (local_count > 0) {
-                        for (0..local_count) |l| {
-                            const type_count = contents[index];
-                            index += 1;
-                            locals[l].types = contents[index..(index + type_count)];
-                            index += type_count;
-                        }
-                    } else {
-                        locals = &[_]Local{};
+            std.wasm.Section.start => {
+                // TODO: unimplemented
+                try stream.skipBytes(section_size, .{});
+            },
+            std.wasm.Section.element => {
+                // TODO: unimplemented
+                try stream.skipBytes(section_size, .{});
+            },
+            std.wasm.Section.code => {
+                const code_count = try std.leb.readUleb128(u32, stream);
+                code = try allocator.alloc(FunctionBody, code_count);
+                for (0..code_count) |i| {
+                    const code_size = try std.leb.readUleb128(u32, stream);
+                    const local_count = try std.leb.readUleb128(u32, stream);
+                    const locals = try allocator.alloc(Local, local_count);
+                    for (locals) |*l| {
+                        const n = try std.leb.readUleb128(u32, stream);
+                        l.types = try allocator.alloc(u8, n);
+                        @memset(l.types, try stream.readByte());
                     }
-
                     code[i].locals = locals;
 
-                    code[i].code = contents[index..(index + (function_size - local_count))];
-                    index += function_size - local_count;
+                    // TODO: maybe is better to parse code into ast here and not do it every frame?
+                    // FIXME: This calculation is plain wrong. Resolving above TODO should help
+                    code[i].code = try allocator.alloc(u8, code_size - local_count - 1);
+                    // TODO: better error reporting
+                    if (try stream.read(code[i].code) != code_size - local_count - 1) return Error.malformed_wasm;
 
                     const f = Function{ .internal = @intCast(i) };
                     try funcs.append(f);
                 }
             },
-            else => index += sec_size + 2,
+            std.wasm.Section.data => {
+                // TODO: unimplemented
+                try stream.skipBytes(section_size, .{});
+            },
+            std.wasm.Section.data_count => {
+                // TODO: unimplemented
+                try stream.skipBytes(section_size, .{});
+            },
+            else => return Error.malformed_wasm,
         }
-
-        byte = contents[index];
+    } else |err| switch (err) {
+        error.EndOfStream => {},
+        else => return err,
     }
 
     return Module{
         .types = types,
         .imports = imports,
-        .contents = contents,
         .functions = functions,
         .memory = memory,
         .exports = exports,

--- a/src/vm/vm.zig
+++ b/src/vm/vm.zig
@@ -79,8 +79,8 @@ pub const Runtime = struct {
                     try self.stack.append(frame.locals[integer.@"1"]);
                 },
                 0x6a => {
-                    const a = self.stack.pop();
-                    const b = self.stack.pop();
+                    const a = self.stack.pop().?;
+                    const b = self.stack.pop().?;
                     try self.stack.append(.{ .i32 = a.i32 + b.i32 });
                 },
                 0x10 => {

--- a/src/vm/vm.zig
+++ b/src/vm/vm.zig
@@ -4,11 +4,20 @@ const Parser = @import("parse.zig");
 const Allocator = std.mem.Allocator;
 const AllocationError = error{OutOfMemory};
 
-pub fn leb128Decode(comptime T: type, bytes: []u8) struct { usize, T } {
-    var result = @as(T, 0);
-    var shift = @as(if (T == u32) u5 else u10, 0);
+pub fn leb128Decode(comptime T: type, bytes: []u8) struct { len: usize, val: T } {
+    switch (@typeInfo(T)) {
+        .int => {},
+        else => @compileError("LEB128 integer decoding only support integers, but got " ++ @typeName(T)),
+    }
+    if (@typeInfo(T).int.bits != 32 and @typeInfo(T).int.bits != 64) {
+        @compileError("LEB128 integer decoding only supports 32 or 64 bits integers but got " ++ std.fmt.comptimePrint("{d} bits", .{@typeInfo(T).int.bits} ));
+    }
+
+    var result: T = 0;
+    // TODO: is the type of shift important. Reading Wikipedia (not very much tho) it seems like we can use u32 and call it a day...
+    var shift: if (@typeInfo(T).int.bits == 32) u5 else u10 = 0;
     var byte: u8 = undefined;
-    var len = @as(usize, 0);
+    var len: usize = 0;
     for (bytes) |b| {
         len += 1;
         result |= @as(T, @intCast((b & 0x7f))) << shift;
@@ -18,16 +27,14 @@ pub fn leb128Decode(comptime T: type, bytes: []u8) struct { usize, T } {
         }
         shift += 7;
     }
-    if (T == i32 or T == i64) {
+    if (@typeInfo(T).int.signedness == .signed) {
         const size = @sizeOf(T) * 8;
         if (shift < size and (byte & 0x40) != 0) {
             result |= (~0 << shift);
         }
-    } else if (T != u64 and T != u32) {
-        @compileError("LEB128 integer decoding only supports 32 or 64 bits integers.");
     }
 
-    return .{ len, result };
+    return .{ .len = len, .val = result };
 }
 
 pub const CallFrame = struct {
@@ -75,8 +82,8 @@ pub const Runtime = struct {
                 0x20 => {
                     const integer = leb128Decode(u32, frame.code[frame.program_counter..]);
 
-                    frame.program_counter += integer.@"0";
-                    try self.stack.append(frame.locals[integer.@"1"]);
+                    frame.program_counter += integer.len;
+                    try self.stack.append(frame.locals[integer.val]);
                 },
                 0x6a => {
                     const a = self.stack.pop().?;
@@ -85,9 +92,9 @@ pub const Runtime = struct {
                 },
                 0x10 => {
                     const integer = leb128Decode(u32, frame.code[frame.program_counter..]);
-                    frame.program_counter += integer.@"0";
+                    frame.program_counter += integer.len;
 
-                    self.call(allocator, integer.@"1", &[_]usize{}) catch {};
+                    self.call(allocator, integer.val, &[_]usize{}) catch {};
                 },
                 0xb => break :loop,
                 else => {},

--- a/src/vm/wasm.zig
+++ b/src/vm/wasm.zig
@@ -29,8 +29,8 @@ pub const GlobalRuntime = struct {
 };
 
 pub fn debug(stack: *std.ArrayList(vm.Value)) void {
-    const a = stack.pop();
-    const b = stack.pop();
+    const a = stack.pop().?;
+    const b = stack.pop().?;
 
     std.debug.print("{}\n", .{a.i32 + b.i32});
 }


### PR DESCRIPTION
There are two main changes in this PR:
1. Separate opengl and vulkan backend implementations
2. Refactor WASM parsing code. I've mostly left the code as it was but I believe using a `Reader` rather than keeping track of the `index` is less error prone. I left a TODO here to refactor the locals, I think we could use only one array of `u8` for function locals. I also left a TODO because the code size calculation is wrong[^1]. Maybe we should try to the generate an ast (or a better assembly?) when parsing a `.wasm` file rather than doing it at runtime? I am not sure about this but the documentation seems to suggest that this should be the way it is done.

[^1]: It is true that this is because I am using a `Reader` and with the `index` approach we can know the size of the locals and therefore the size of the code. But I think the size calculation was wrong anyways...